### PR TITLE
Fix sample code in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,12 +4,22 @@ string representation by drawing the captured image onto a 2D Canvas
 and use [@LazarSoft/jsqrcode](https://github.com/LazarSoft/jsqrcode) to check for a valid QRCode every *Xms*
 
 ```html
-   <qr-scanner
-      [debug]="false"        <!-- debug flag for console.log spam              (default: false) -->
-      [canvasWidth]="640"    <!-- canvas width                                 (default: 640) -->
-      [canvasHeight]="480"   <!-- canvas height                                (default: 480) -->
-      [mirror]="false"       <!-- should the image be a mirror?                (default: false) -->
-      [stopAfterScan]="true" <!-- should the scanner stop after first success? (default: true) -->
-      [updateTime]="500"     <!-- miliseconds between new capture              (default: 500) -->
-      (onRead)="decodedOutput(string)"></qr-scanner>
+<!--
+Component attributes
+[debug]         debug flag for console.log spam              (default: false)
+[canvasWidth]   canvas width                                 (default: 640)
+[canvasHeight]  canvas height                                (default: 480)
+[mirror]        should the image be a mirror?                (default: false)
+[stopAfterScan] should the scanner stop after first success? (default: true)
+[updateTime]    miliseconds between new capture              (default: 500)
+(onRead)        callback when qr code is detected
+-->
+<qr-scanner
+   [debug]="false"        
+   [canvasWidth]="640"    
+   [canvasHeight]="480"   
+   [mirror]="false"       
+   [stopAfterScan]="true" 
+   [updateTime]="500"     
+   (onRead)="decodedOutput($event)"></qr-scanner>
 ```


### PR DESCRIPTION
Fixed two issues:
1. The original sample code wasn't valid HTML. So copy-pasted code isn't working.
2. `decodedOutput(string)` wasn't working. Should be `decodedOutput($event)`;