### PR TITLE
OnDestroy exception fix

### DIFF
--- a/src/qrscanner.component.ts
+++ b/src/qrscanner.component.ts
@@ -103,8 +103,9 @@ export class QrScannerComponent implements OnInit, OnDestroy, AfterViewInit {
             clearTimeout(this.captureTimeout);
             this.captureTimeout = false;
         }
-
-        this.stream.getTracks()[0].stop();
+        if (this.stream != null) {
+            this.stream.getTracks()[0].stop();
+        }
         this.stop = true;
     }
 


### PR DESCRIPTION
Keeps throwing exception on OnDestroy on devices where the stream could not be opened because the device doesn't support camera device.